### PR TITLE
Polish chat bubbles and sidebar unread indicators

### DIFF
--- a/Sources/Noodle/ChatView.swift
+++ b/Sources/Noodle/ChatView.swift
@@ -248,6 +248,7 @@ private struct ConversationTranscript: View {
                 ForEach(store.messages(for: conversation)) { message in
                     MessageBubble(
                         message: message,
+                        hasConversationBackground: !store.background(for: conversation).isDefault,
                         selectedAttachmentID: $selectedAttachmentID,
                         previewAttachment: previewAttachment
                     )

--- a/Sources/Noodle/Components.swift
+++ b/Sources/Noodle/Components.swift
@@ -113,6 +113,7 @@ struct MessageBubble: View {
     @State private var inspectedReaction: String?
     @State private var changingReaction = false
     let message: ChatMessage
+    let hasConversationBackground: Bool
     @Binding var selectedAttachmentID: UUID?
     let previewAttachment: (ConversationAttachment) -> Void
 
@@ -138,10 +139,7 @@ struct MessageBubble: View {
                     .textSelection(.enabled)
                     .padding(.horizontal, 13)
                     .padding(.vertical, 8)
-                    .background(
-                        isUser ? Color.accentColor : Color(nsColor: .controlBackgroundColor),
-                        in: RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    )
+                    .background { messageBackground }
                     .overlay {
                         reactionContextMenu(attachment: nil)
                     }
@@ -176,6 +174,20 @@ struct MessageBubble: View {
             if !isUser { Spacer(minLength: 120) }
         }
         .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
+    @ViewBuilder private var messageBackground: some View {
+        let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+
+        if hasConversationBackground {
+            shape
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    shape.fill(isUser ? Color.accentColor.opacity(0.28) : Color.black.opacity(0.22))
+                }
+        } else {
+            shape.fill(isUser ? Color.accentColor : Color(white: 0.20))
+        }
     }
 
     private var hasReactions: Bool { !(message.reactions ?? []).isEmpty }

--- a/Sources/Noodle/SidebarView.swift
+++ b/Sources/Noodle/SidebarView.swift
@@ -76,12 +76,6 @@ private struct ConversationRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            Circle()
-                .fill(Color.accentColor)
-                .frame(width: 8, height: 8)
-                .opacity(store.hasUnreadMessages(in: conversation) ? 1 : 0)
-                .accessibilityHidden(true)
-
             ZStack(alignment: .bottomTrailing) {
                 ConversationAvatar(
                     participants: store.participants(for: conversation),
@@ -92,6 +86,14 @@ private struct ConversationRow: View {
                     .fill(runtimeColor)
                     .frame(width: 10, height: 10)
                     .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 2))
+            }
+            .overlay(alignment: .topLeading) {
+                Circle()
+                    .fill(Color.accentColor)
+                    .frame(width: 8, height: 8)
+                    .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 2))
+                    .opacity(store.hasUnreadMessages(in: conversation) ? 1 : 0)
+                    .accessibilityHidden(true)
             }
 
             VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
## Summary
- Adapt message bubble styling for conversations with custom backgrounds.
- Improve default bubble contrast and material treatment over custom backgrounds.
- Move unread indicators onto conversation avatars with a background-colored outline.

## Testing
- Not run (UI-only changes).