### PR TITLE
Show a typing indicator while bots work on a reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Noodle are documented here, following
 
 ## [Unreleased]
 
+### Added
+
+- Show a typing indicator above the composer while a bot works on a reply to that conversation, for every harness. It appears only where the bot was messaged, hides as soon as the bot replies and returns if the bot keeps working, carries over to queued turns, and stays hidden for heartbeats and pending approvals.
+
 ## [0.12.1] - 2026-09-12
 
 ### Fixed

--- a/Sources/Noodle/AgentRuntimeCoordinator.swift
+++ b/Sources/Noodle/AgentRuntimeCoordinator.swift
@@ -43,6 +43,7 @@ final class AgentRuntimeCoordinator {
     private(set) var lastHeartbeatDates: [UUID: Date]
     private(set) var accessConfiguration: AgentAccessConfiguration
     private(set) var approvals: [AgentApprovalRequest] = []
+    private(set) var typing = AgentTypingTracker()
     private(set) var changingAccess: Set<UUID> = []
     @ObservationIgnored private let sleepController = AgentActivitySleepController()
     private var lifecycleID = UUID()
@@ -480,16 +481,7 @@ final class AgentRuntimeCoordinator {
                 workspaceURL: repository.directory(for: agent),
                 extendedAccess: accessConfiguration.isExtended(for: agent),
                 recoverInterruptedWork: recoveryPending.remove(agent.id) != nil,
-                onSnapshot: { [weak self] snapshot in
-                    if self?.snapshots[snapshot.agentID]?.phase == .working,
-                       snapshot.phase == .ready {
-                        self?.recordActivity(for: snapshot.agentID)
-                    }
-                    self?.snapshots[snapshot.agentID] = snapshot
-                    if snapshot.phase == .ready {
-                        self?.markStable(agentID: snapshot.agentID)
-                    }
-                },
+                onSnapshot: runtimeSnapshotHandler(for: agent.id),
                 onHeartbeat: { [weak self] in
                     self?.recordHeartbeat(for: agent.id)
                 },
@@ -565,7 +557,10 @@ final class AgentRuntimeCoordinator {
         if let old { old.stop(completion: finish) } else { finish(true) }
     }
 
-    func notify(_ agents: [AgentRecord], repository: WorkspaceRepository) {
+    /// Pass the conversation when the bots are expected to answer there, so it
+    /// shows them typing while they work.
+    func notify(_ agents: [AgentRecord], awaitingReplyIn conversationID: UUID? = nil, repository: WorkspaceRepository) {
+        if let conversationID { expectReply(from: agents.map(\.id), in: conversationID) }
         for agent in agents {
             recordActivity(for: agent.id)
             if processes[agent.id] == nil {
@@ -575,11 +570,32 @@ final class AgentRuntimeCoordinator {
         }
     }
 
+    func expectReply(from agentIDs: [UUID], in conversationID: UUID) {
+        typing.expectReply(from: agentIDs, in: conversationID)
+    }
+
+    /// Long tasks often start with a short "on it" reply; typing returns if
+    /// the bot is still working after this delay.
+    func agentReplied(_ agentID: UUID, in conversationID: UUID) {
+        guard let token = typing.pause(agentID, in: conversationID) else { return }
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            self?.typing.resume(agentID, in: conversationID, token: token)
+        }
+    }
+
+    /// Hidden while the bot waits on an approval, which already shows above the composer.
+    func isTyping(_ agentID: UUID, in conversationID: UUID) -> Bool {
+        !approvals.contains { $0.agentID == agentID }
+            && typing.isTyping(agentID, in: conversationID, phase: snapshot(for: agentID).phase)
+    }
+
     func stop(agentID: UUID) {
         cancelSupervision(for: agentID)
         recoveryPending.remove(agentID)
         changingAccess.remove(agentID)
         approvals.removeAll { $0.agentID == agentID }
+        typing.remove(agentID)
         accessConfiguration.remove(agentID)
         accessConfiguration.save(to: defaults)
         processes.removeValue(forKey: agentID)?.stop { _ in }
@@ -598,6 +614,7 @@ final class AgentRuntimeCoordinator {
         lifecycleID = UUID()
         changingAccess = []
         approvals = []
+        typing = AgentTypingTracker()
         capabilityProbe?.stop()
         capabilityProbe = nil
         restartTasks.values.forEach { $0.cancel() }
@@ -700,6 +717,7 @@ final class AgentRuntimeCoordinator {
                 self?.recordActivity(for: snapshot.agentID)
             }
             self?.snapshots[snapshot.agentID] = snapshot
+            self?.typing.update(snapshot, hasPendingWork: self?.processes[agentID]?.hasInterruptedWork ?? false)
             if snapshot.phase == .ready { self?.markStable(agentID: agentID) }
         }
     }

--- a/Sources/Noodle/ChatView.swift
+++ b/Sources/Noodle/ChatView.swift
@@ -131,12 +131,21 @@ struct ChatView: View {
     }
 
     private var pinnedBottomContent: some View {
-        VStack(spacing: 0) {
+        let typing = store.typingParticipants(in: conversation)
+        return VStack(spacing: 0) {
             if let request = store.runtime.approvals.first(where: { conversation.participantIDs.contains($0.agentID) }) {
                 AgentApprovalView(request: request).id(request.id)
             }
+            if !typing.isEmpty {
+                TypingIndicator(agents: typing)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 6)
+                    .transition(.opacity)
+            }
             composerFooter
         }
+        .animation(.easeOut(duration: 0.2), value: typing.map(\.id))
     }
 
     private var topFadedTranscript: some View {

--- a/Sources/Noodle/NoodleStore.swift
+++ b/Sources/Noodle/NoodleStore.swift
@@ -454,7 +454,7 @@ final class NoodleStore {
             conversations.sort { $0.updatedAt > $1.updatedAt }
         }
         // Existing text and file drafts are independent and remain untouched.
-        runtime.notify(participants(for: conversation), repository: repository)
+        runtime.notify(participants(for: conversation), awaitingReplyIn: conversationID, repository: repository)
     }
 
     func sendDraft() {
@@ -477,7 +477,7 @@ final class NoodleStore {
             }
 
             drafts.clear(conversation.id)
-            runtime.notify(participants(for: conversation), repository: repository)
+            runtime.notify(participants(for: conversation), awaitingReplyIn: conversation.id, repository: repository)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -497,7 +497,7 @@ final class NoodleStore {
             conversations[index].updatedAt = message.createdAt
             conversations.sort { $0.updatedAt > $1.updatedAt }
         }
-        runtime.notify(participants(for: conversation), repository: repository)
+        runtime.notify(participants(for: conversation), awaitingReplyIn: conversation.id, repository: repository)
         return message
     }
 
@@ -877,7 +877,10 @@ final class NoodleStore {
         if snapshot.messagesChanged { messagesByConversation = snapshot.messages }
         if snapshot.attachmentsChanged { attachmentsByConversation = snapshot.attachments }
         for message in newAgentMessages {
-            if case .agent(let id) = message.author { runtime.recordActivity(for: id) }
+            if case .agent(let id) = message.author {
+                runtime.recordActivity(for: id)
+                runtime.agentReplied(id, in: message.conversationID)
+            }
         }
         notifyGroupParticipants(for: newAgentMessages)
         for change in reactionChanges {
@@ -898,6 +901,10 @@ final class NoodleStore {
         conversation.participantIDs.compactMap { id in
             agents.first(where: { $0.id == id })
         }
+    }
+
+    func typingParticipants(in conversation: BotConversation) -> [AgentRecord] {
+        participants(for: conversation).filter { runtime.isTyping($0.id, in: conversation.id) }
     }
 
     func toggleReaction(_ emoji: String, on message: ChatMessage) {
@@ -997,7 +1004,7 @@ final class NoodleStore {
                     }.value
                     refreshTranscripts()
                     if let conversation = conversations.first(where: { $0.id == message.conversationID }) {
-                        runtime.notify(participants(for: conversation), repository: repository)
+                        runtime.notify(participants(for: conversation), awaitingReplyIn: conversation.id, repository: repository)
                     }
                     try await Task.detached { try inbox.acknowledge(request.id) }.value
                 } catch {
@@ -1014,6 +1021,12 @@ final class NoodleStore {
         do {
             let recipientIDs = try repository.notificationRecipientIDs(for: messages)
             let recipients = agents.filter { recipientIDs.contains($0.id) }
+            for message in messages {
+                guard case .agent(let senderID) = message.author,
+                      let conversation = conversations.first(where: { $0.id == message.conversationID }),
+                      conversation.kind == .group else { continue }
+                runtime.expectReply(from: conversation.participantIDs.filter { $0 != senderID }, in: conversation.id)
+            }
             if !recipients.isEmpty {
                 runtime.notify(recipients, repository: repository)
             }

--- a/Sources/Noodle/TypingIndicator.swift
+++ b/Sources/Noodle/TypingIndicator.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import NoodleCore
+
+/// Bots working on a reply in the open conversation, shown above the composer.
+struct TypingIndicator: View {
+    let agents: [AgentRecord]
+
+    var body: some View {
+        HStack(spacing: 7) {
+            HStack(spacing: -6) {
+                ForEach(agents.prefix(3)) { agent in
+                    BotAvatar(agent: agent, size: 18, showsShadow: false)
+                }
+            }
+            TypingDots()
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .modifier(TypingIndicatorBackground())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        let first = agents.first?.displayName ?? ""
+        return switch agents.count {
+        case 1: "\(first) is typing…"
+        case 2: "\(first) and \(agents[1].displayName) are typing…"
+        default: "\(first) and \(agents.count - 1) others are typing…"
+        }
+    }
+}
+
+private struct TypingDots: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1 / 30, paused: reduceMotion)) { context in
+            let time = context.date.timeIntervalSinceReferenceDate
+            HStack(spacing: 3) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .frame(width: 5, height: 5)
+                        .opacity(reduceMotion ? 0.6 : opacity(at: time, index: index))
+                }
+            }
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    private func opacity(at time: TimeInterval, index: Int) -> Double {
+        let wave = sin(time * 2 * .pi / 1.2 - Double(index) * 0.9)
+        return 0.3 + 0.7 * (wave + 1) / 2
+    }
+}
+
+private struct TypingIndicatorBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular, in: Capsule())
+        } else {
+            content
+        }
+    }
+}

--- a/Sources/NoodleCore/AgentTyping.swift
+++ b/Sources/NoodleCore/AgentTyping.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Conversations each bot is expected to answer. Wakes carry no conversation,
+/// so the app records where it notified a bot and shows typing only there.
+public struct AgentTypingTracker: Equatable, Sendable {
+    private var conversations: [UUID: Set<UUID>] = [:]
+    /// Hidden after a reply; the token lets only the latest reply resume it.
+    private var paused: [UUID: [UUID: UUID]] = [:]
+
+    public init() {}
+
+    public mutating func expectReply(from agentIDs: some Sequence<UUID>, in conversationID: UUID) {
+        for id in agentIDs {
+            conversations[id, default: []].insert(conversationID)
+            paused[id]?[conversationID] = nil
+        }
+    }
+
+    /// Harnesses finish their turn a moment after the reply lands, so hide
+    /// typing with the reply and resume it only if the bot keeps working.
+    public mutating func pause(_ agentID: UUID, in conversationID: UUID) -> UUID? {
+        guard conversations[agentID]?.contains(conversationID) == true else { return nil }
+        let token = UUID()
+        paused[agentID, default: [:]][conversationID] = token
+        return token
+    }
+
+    public mutating func resume(_ agentID: UUID, in conversationID: UUID, token: UUID) {
+        guard paused[agentID]?[conversationID] == token else { return }
+        paused[agentID]?[conversationID] = nil
+    }
+
+    /// Drivers report `ready` before starting a queued turn, so pending work
+    /// keeps the expectation alive for the turn that follows.
+    public mutating func update(_ snapshot: AgentRuntimeSnapshot, hasPendingWork: Bool) {
+        guard !snapshot.phase.isBusy else { return }
+        paused[snapshot.agentID] = nil
+        if !hasPendingWork { conversations[snapshot.agentID] = nil }
+    }
+
+    public mutating func remove(_ agentID: UUID) {
+        conversations[agentID] = nil
+        paused[agentID] = nil
+    }
+
+    public func isTyping(_ agentID: UUID, in conversationID: UUID, phase: AgentRuntimePhase) -> Bool {
+        phase.isBusy && conversations[agentID]?.contains(conversationID) == true
+            && paused[agentID]?[conversationID] == nil
+    }
+}
+
+extension AgentRuntimePhase {
+    var isBusy: Bool { self == .starting || self == .working }
+}

--- a/Tests/NoodleCoreTests/AgentTypingTests.swift
+++ b/Tests/NoodleCoreTests/AgentTypingTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import NoodleCore
+
+final class AgentTypingTests: XCTestCase {
+    private let bot = UUID()
+    private let other = UUID()
+    private let direct = UUID()
+    private let group = UUID()
+
+    private func snapshot(_ phase: AgentRuntimePhase, _ agentID: UUID? = nil) -> AgentRuntimeSnapshot {
+        AgentRuntimeSnapshot(agentID: agentID ?? bot, phase: phase, detail: "")
+    }
+
+    func testTypingOnlyInNotifiedConversationWhileBusy() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .working))
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .starting))
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .ready))
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .failed))
+        XCTAssertFalse(tracker.isTyping(bot, in: group, phase: .working))
+        XCTAssertFalse(tracker.isTyping(other, in: direct, phase: .working))
+    }
+
+    func testUnnotifiedWorkSuchAsHeartbeatsIsNotTyping() {
+        let tracker = AgentTypingTracker()
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testFinishedTurnClearsEveryConversation() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        tracker.expectReply(from: [bot], in: group)
+        tracker.update(snapshot(.working), hasPendingWork: true)
+        tracker.update(snapshot(.ready), hasPendingWork: false)
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .working))
+        XCTAssertFalse(tracker.isTyping(bot, in: group, phase: .working))
+    }
+
+    func testQueuedMessageSurvivesTheReadyBetweenTurns() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        tracker.update(snapshot(.ready), hasPendingWork: true)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testInterruptedWorkSurvivesFailureForRecovery() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        tracker.update(snapshot(.failed), hasPendingWork: true)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .starting))
+        tracker.update(snapshot(.failed), hasPendingWork: false)
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .starting))
+    }
+
+    func testReplyHidesTypingUntilResumed() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        let token = tracker.pause(bot, in: direct)
+        XCTAssertNotNil(token)
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .working))
+        tracker.resume(bot, in: direct, token: token!)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testOnlyTheLatestReplyResumesTyping() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        let first = tracker.pause(bot, in: direct)!
+        _ = tracker.pause(bot, in: direct)
+        tracker.resume(bot, in: direct, token: first)
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testReplyInUnexpectedConversationIsIgnored() {
+        var tracker = AgentTypingTracker()
+        XCTAssertNil(tracker.pause(bot, in: direct))
+    }
+
+    func testNewUserMessageOrNextTurnShowsTypingAgain() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        _ = tracker.pause(bot, in: direct)
+        tracker.expectReply(from: [bot], in: direct)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .working))
+
+        _ = tracker.pause(bot, in: direct)
+        tracker.update(snapshot(.ready), hasPendingWork: true)
+        XCTAssertTrue(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testFinishedTurnDiscardsPendingResume() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot], in: direct)
+        let token = tracker.pause(bot, in: direct)!
+        tracker.update(snapshot(.ready), hasPendingWork: false)
+        tracker.resume(bot, in: direct, token: token)
+        XCTAssertFalse(tracker.isTyping(bot, in: direct, phase: .working))
+    }
+
+    func testOneBotFinishingDoesNotClearAnother() {
+        var tracker = AgentTypingTracker()
+        tracker.expectReply(from: [bot, other], in: group)
+        tracker.update(snapshot(.ready, other), hasPendingWork: false)
+        XCTAssertTrue(tracker.isTyping(bot, in: group, phase: .working))
+        XCTAssertFalse(tracker.isTyping(other, in: group, phase: .working))
+        tracker.remove(bot)
+        XCTAssertFalse(tracker.isTyping(bot, in: group, phase: .working))
+    }
+}


### PR DESCRIPTION
## Summary

Without any in-chat feedback, a bot that is busy with a reply looks unresponsive. This adds a typing indicator above the composer ("Codex is typing…", "A and B are typing…", "A and 2 others are typing…") with the bot's avatar and animated dots.

- **Every harness.** It is derived from the shared `AgentRuntimeSnapshot` phase, so Codex, Claude Code, FX, Grok Build and Muse Code need no driver-specific code.
- **Only in the conversation that was messaged.** Wakes carry no conversation, so the coordinator records where it notified each bot (`AgentTypingTracker` in NoodleCore). User messages, voice messages, Shortcuts and shared items mark the conversation, and so do bot messages in groups for the other members. Heartbeats and reactions do not.
- **Hides with the reply.** Harnesses finish their turn a moment after the Messenger reply lands, so the reply hides typing at once. If the bot is still working five seconds later (for example after an "on it" message), typing returns.
- **Turn boundaries.** All drivers report `ready` before starting a queued turn, so pending work keeps the expectation for the next turn. It clears when the bot finishes with no pending work, or when the bot is stopped.
- **Hidden while an approval is pending**, since the approval card already occupies that spot.
- Dots stay still with Reduce Motion. On macOS 26 the indicator uses a glass capsule; on macOS 15 it sits on the existing bar background.

The indicator is placed above the composer rather than in the transcript, so it does not interact with `TranscriptScrollView`'s anchoring.

Codex now uses the shared `runtimeSnapshotHandler`; its inline closure was identical.

## Verification

- `swift test --disable-sandbox --filter AgentTypingTests`: 11 new tests pass. They cover conversation scoping, queued turns, failure recovery, pause/resume tokens, and discarding stale resumes.
- `swift test --disable-sandbox`: 435 tests, 1 failure in `ToolCatalogTests.testSearchAndCustomMCPStaySeparate`. That test fails identically on `main` without this change.
- Manually tested in a local debug build on macOS 26: typing appears after sending, hides when the reply arrives, and returns while the bot keeps working.

## Visual changes

- [ ] No visual changes
- [x] Visual changes included below

### Before

No in-chat indication while a bot works.

### After

Screenshot to follow.

## Checklist

- [x] I tested the affected user flow
- [ ] I considered both default and custom conversation backgrounds where relevant
- [ ] I checked single-line and multiline layouts where relevant
- [ ] I checked the macOS 15 fallback when using newer macOS APIs

