### PR TITLE
Add scroll-to-top and scroll-to-latest transcript buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Noodle are documented here, following
 
 ## [Unreleased]
 
+### Added
+
+- Show Scroll to Top and Scroll to Latest buttons above the composer while scrolling a conversation. Each appears only away from its edge, both fade two seconds after scrolling stops, and they stay while hovered.
+
+### Fixed
+
+- Recognize the bottom of a conversation under the window's titlebar inset, so a transcript scrolled back to the bottom by hand follows new messages again.
+
 ## [0.12.1] - 2026-09-12
 
 ### Fixed

--- a/Sources/Noodle/TranscriptScrollView.swift
+++ b/Sources/Noodle/TranscriptScrollView.swift
@@ -14,8 +14,46 @@ enum TranscriptScrollTarget: Hashable, Sendable {
 
 private struct TranscriptGeometry: Equatable {
     let viewport: TranscriptViewport
+    let isAtTop: Bool
     let contentHeight: CGFloat
     let containerHeight: CGFloat
+}
+
+/// Changes only at the edges, so jump controls don't update on every scrolled pixel.
+private struct TranscriptEdges: Equatable {
+    var isAtTop: Bool
+    var isAtBottom: Bool
+}
+
+/// Kept out of the scroll view's own state, so showing or fading a control
+/// re-renders only the controls, never the ScrollView.
+@MainActor @Observable
+private final class TranscriptJumpState {
+    var edges: TranscriptEdges
+    var recentlyScrolled = false
+    @ObservationIgnored private var hovering = false
+    @ObservationIgnored private var hideTask: Task<Void, Never>?
+
+    init(isAtBottom: Bool) { edges = TranscriptEdges(isAtTop: false, isAtBottom: isAtBottom) }
+
+    func scrollingBegan() {
+        hideTask?.cancel()
+        if !recentlyScrolled { recentlyScrolled = true }
+    }
+
+    func scheduleHide() {
+        hideTask?.cancel()
+        hideTask = Task { [weak self] in
+            do { try await Task.sleep(for: .seconds(2)) } catch { return }
+            guard let self, !self.hovering else { return }
+            self.recentlyScrolled = false
+        }
+    }
+
+    func setHovering(_ hovering: Bool) {
+        self.hovering = hovering
+        if hovering { hideTask?.cancel() } else if recentlyScrolled { scheduleHide() }
+    }
 }
 
 /// Records geometry without publishing a SwiftUI update for every scrolled pixel.
@@ -41,6 +79,8 @@ struct TranscriptScrollView<Content: View>: View {
     @State private var userIsScrolling = false
     @State private var userHasScrolled = false
     @State private var didRestoreInitialViewport = false
+    @State private var jumpState: TranscriptJumpState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     init(initialViewport: TranscriptViewport, lastMessageID: UUID?, lastMessageIsFromUser: Bool,
          bottomOverlayHeight: CGFloat, saveViewport: @escaping (TranscriptViewport) -> Void,
@@ -57,6 +97,7 @@ struct TranscriptScrollView<Content: View>: View {
         _position = State(initialValue: initialPosition)
         _viewportRecorder = State(initialValue: TranscriptViewportRecorder(initialViewport))
         _followsLatest = State(initialValue: initialViewport.isAtBottom)
+        _jumpState = State(initialValue: TranscriptJumpState(isAtBottom: initialViewport.isAtBottom))
     }
 
     var body: some View {
@@ -98,16 +139,11 @@ struct TranscriptScrollView<Content: View>: View {
             position.scrollTo(id: target, anchor: initialViewport.isAtBottom ? .bottom : .top)
         }
         .onScrollGeometryChange(for: TranscriptGeometry.self) { geometry in
-            let metrics = TranscriptScrollMetrics(
-                contentOffset: geometry.contentOffset.y,
-                contentHeight: geometry.contentSize.height,
-                viewportHeight: geometry.containerSize.height,
-                topInset: geometry.contentInsets.top,
-                bottomInset: geometry.contentInsets.bottom
-            )
+            let metrics = Self.metrics(geometry)
             return TranscriptGeometry(
                 // ScrollPosition(y:) uses the inset-adjusted top, not raw offset.
                 viewport: TranscriptViewport(offset: metrics.offset, isAtBottom: metrics.isAtBottom),
+                isAtTop: metrics.isAtTop,
                 contentHeight: geometry.contentSize.height,
                 containerHeight: geometry.containerSize.height
             )
@@ -122,6 +158,9 @@ struct TranscriptScrollView<Content: View>: View {
             }
             // Never write ScrollPosition here: native identity anchoring handles
             // reflow without a geometry -> corrective scroll -> geometry loop.
+            // Published only at the edges, not for every scrolled pixel.
+            let edges = TranscriptEdges(isAtTop: updated.isAtTop, isAtBottom: updated.viewport.isAtBottom)
+            if jumpState.edges != edges { jumpState.edges = edges }
         }
         .onScrollPhaseChange { oldPhase, newPhase in
             let wasUserScrolling = oldPhase != .idle && oldPhase != .animating
@@ -130,13 +169,20 @@ struct TranscriptScrollView<Content: View>: View {
             if isUserScrolling {
                 userHasScrolled = true
                 didRestoreInitialViewport = true
+                jumpState.scrollingBegan()
             }
             if wasUserScrolling && !isUserScrolling {
                 let finalViewport = readingViewport()
                 followsLatest = finalViewport.isAtBottom
                 viewportRecorder.lastUserViewport = finalViewport
                 saveViewport(finalViewport)
+                jumpState.scheduleHide()
             }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            TranscriptJumpControls(state: jumpState, jump: jump)
+                .padding(.trailing, 18)
+                .padding(.bottom, bottomOverlayHeight + 12)
         }
         .onChange(of: lastMessageID) { _, _ in
             // Initial hydration isn't a newly sent message, even if the last
@@ -168,5 +214,77 @@ struct TranscriptScrollView<Content: View>: View {
 
     private func saveLastUserViewport() {
         if let viewport = viewportRecorder.lastUserViewport { saveViewport(viewport) }
+    }
+
+    private func jump(to target: TranscriptScrollTarget) {
+        let toBottom = target == .bottom
+        userHasScrolled = true
+        didRestoreInitialViewport = true
+        followsLatest = toBottom
+        withAnimation(reduceMotion ? nil : .smooth(duration: 0.35)) {
+            // The top edge needs no row: content may not provide a `.start` target,
+            // and no estimated lazy-row height lies above offset zero.
+            if toBottom { position.scrollTo(id: target, anchor: .bottom) } else { position.scrollTo(edge: .top) }
+        }
+        let viewport = TranscriptViewport(offset: 0, isAtBottom: toBottom)
+        viewportRecorder.lastUserViewport = viewport
+        saveViewport(viewport)
+        jumpState.scheduleHide()
+    }
+
+    private static func metrics(_ geometry: ScrollGeometry) -> TranscriptScrollMetrics {
+        TranscriptScrollMetrics(
+            contentOffset: geometry.contentOffset.y,
+            contentHeight: geometry.contentSize.height,
+            // containerSize excludes the titlebar inset (758 vs 810 pt measured),
+            // which kept isAtBottom false at the real bottom; visibleRect is full height.
+            viewportHeight: geometry.visibleRect.height,
+            topInset: geometry.contentInsets.top,
+            bottomInset: geometry.contentInsets.bottom
+        )
+    }
+}
+
+private struct TranscriptJumpControls: View {
+    let state: TranscriptJumpState
+    let jump: (TranscriptScrollTarget) -> Void
+
+    var body: some View {
+        let showsTop = state.recentlyScrolled && !state.edges.isAtTop
+        let showsBottom = state.recentlyScrolled && !state.edges.isAtBottom
+        VStack(spacing: 8) {
+            if showsTop { button("chevron.up", title: "Scroll to Top", target: .start) }
+            if showsBottom { button("chevron.down", title: "Scroll to Latest", target: .bottom) }
+        }
+        .onHover { state.setHovering($0) }
+        .animation(.easeOut(duration: 0.2), value: showsTop)
+        .animation(.easeOut(duration: 0.2), value: showsBottom)
+    }
+
+    private func button(_ symbol: String, title: String, target: TranscriptScrollTarget) -> some View {
+        Button { jump(target) } label: {
+            Image(systemName: symbol)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+                .frame(width: 30, height: 30)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .modifier(JumpControlBackground())
+        .help(title)
+        .accessibilityLabel(title)
+        .transition(.opacity)
+    }
+}
+
+private struct JumpControlBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular.interactive(), in: Circle())
+        } else {
+            content
+                .background(.regularMaterial, in: Circle())
+                .overlay(Circle().stroke(.separator.opacity(0.5)))
+        }
     }
 }

--- a/Sources/NoodleCore/TranscriptScrollMetrics.swift
+++ b/Sources/NoodleCore/TranscriptScrollMetrics.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct TranscriptScrollMetrics: Equatable, Sendable {
     public let offset: CGFloat
     public let isAtBottom: Bool
+    public let isAtTop: Bool
 
     public init(contentOffset: CGFloat, contentHeight: CGFloat, viewportHeight: CGFloat,
                 topInset: CGFloat, bottomInset: CGFloat) {
@@ -13,5 +14,6 @@ public struct TranscriptScrollMetrics: Equatable, Sendable {
         // A short conversation is already fully visible, even when its raw
         // offset is negative because of the titlebar/safe-area inset.
         isAtBottom = maximumOffset <= 2 || adjustedOffset >= maximumOffset - 2
+        isAtTop = adjustedOffset <= 2
     }
 }

--- a/Tests/NoodleCoreTests/TranscriptScrollMetricsTests.swift
+++ b/Tests/NoodleCoreTests/TranscriptScrollMetricsTests.swift
@@ -31,6 +31,25 @@ final class TranscriptScrollMetricsTests: XCTestCase {
                                                viewportHeight: 800, topInset: 52, bottomInset: 0).offset, 0)
     }
 
+    func testTopUsesTheInsetAdjustedOffset() {
+        for offset: CGFloat in [-70, -52, -50] {
+            XCTAssertTrue(TranscriptScrollMetrics(contentOffset: offset, contentHeight: 2000,
+                                                  viewportHeight: 800, topInset: 52, bottomInset: 0).isAtTop)
+        }
+        XCTAssertFalse(TranscriptScrollMetrics(contentOffset: -40, contentHeight: 2000,
+                                               viewportHeight: 800, topInset: 52, bottomInset: 0).isAtTop)
+    }
+
+    func testMeasuredAppBottomNeedsFullViewportHeight() {
+        // Measured in the app: 810 pt visible, while SwiftUI's containerSize was 758.
+        for offset: CGFloat in [404, 421] {
+            XCTAssertTrue(TranscriptScrollMetrics(contentOffset: offset, contentHeight: 1214,
+                                                  viewportHeight: 810, topInset: 52, bottomInset: 0).isAtBottom)
+        }
+        XCTAssertFalse(TranscriptScrollMetrics(contentOffset: 421, contentHeight: 1214,
+                                               viewportHeight: 758, topInset: 52, bottomInset: 0).isAtBottom)
+    }
+
     func testGrowingConversationBecomesScrollableWithoutChangingOffset() {
         let short = TranscriptScrollMetrics(contentOffset: -52, contentHeight: 300,
                                            viewportHeight: 800, topInset: 52, bottomInset: 0)

--- a/Tests/transcript-resize.swift
+++ b/Tests/transcript-resize.swift
@@ -126,8 +126,55 @@ struct TranscriptResizeFixture: View {
             model.ids.append(UUID())
             await settle()
             precondition(atBottom(), "New messages must still follow when already at the bottom")
+
+            @MainActor func atTop() -> Bool {
+                let inset = scroll.contentInsets
+                return TranscriptScrollMetrics(contentOffset: scroll.contentView.bounds.minY,
+                    contentHeight: scroll.documentView!.frame.height, viewportHeight: scroll.contentView.bounds.height,
+                    topInset: inset.top, bottomInset: inset.bottom).isAtTop
+            }
+            // SwiftUI builds no accessibility tree without a client, so click where the
+            // bottom-anchored controls sit: 18 pt from the edge, 12 pt above the overlay.
+            @MainActor func click(_ control: Int) {
+                let point = NSPoint(x: window.contentView!.bounds.width - 33,
+                                    y: model.overlayHeight + 27 + CGFloat(control) * 38)
+                func event(_ type: NSEvent.EventType) -> NSEvent {
+                    NSEvent.mouseEvent(with: type, location: point, modifierFlags: [],
+                        timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: window.windowNumber,
+                        context: nil, eventNumber: 0, clickCount: 1, pressure: 1)!
+                }
+                // Queue the mouse-up first: a click on message text runs a nested
+                // tracking loop that would otherwise wait for it forever.
+                NSApp.postEvent(event(.leftMouseUp), atStart: false)
+                window.sendEvent(event(.leftMouseDown))
+            }
+            let latest = 0, top = 1
+            wheel(0, phase: .began)
+            wheel(2400, phase: .changed)
+            await settle()
+            wheel(0, phase: .ended)
+            await settle()
+            click(top)
+            try? await Task.sleep(for: .milliseconds(900))
+            precondition(atTop() && !model.saved.isAtBottom, "Scroll to Top must reach and save the start")
+            click(latest)
+            try? await Task.sleep(for: .milliseconds(900))
+            precondition(atBottom() && model.saved.isAtBottom, "Scroll to Latest must reach and save the bottom")
+            model.ids.append(UUID())
+            await settle()
+            precondition(atBottom(), "Jumping to latest must resume following new messages")
+            wheel(0, phase: .began)
+            wheel(1200, phase: .changed)
+            await settle()
+            wheel(0, phase: .ended)
+            try? await Task.sleep(for: .milliseconds(2600))
+            click(top)
+            click(latest)
+            try? await Task.sleep(for: .milliseconds(900))
+            precondition(!atTop() && !atBottom(), "Both controls must hide after scrolling stops")
+
             window.orderOut(nil)
-            print("Transcript resize checks passed: message anchoring, width/height reflow, incoming messages, composer growth and follow-latest")
+            print("Transcript resize checks passed: message anchoring, width/height reflow, incoming messages, composer growth, follow-latest and jump controls")
             exit(0)
         }
         app.run()


### PR DESCRIPTION
## Summary

Long conversations had no quick way back to the latest message or to the start. While you scroll, two small buttons appear at the bottom trailing edge of the transcript, above the composer:

- **Scroll to Latest** (chevron down) appears only away from the bottom. It jumps to the latest message and resumes following new messages.
- **Scroll to Top** (chevron up) appears only away from the top and jumps to the start. It scrolls to the top edge rather than the `.start` row, so it does not depend on the content providing that row.
- Both fade two seconds after scrolling stops and stay visible while hovered. Jumps animate, or jump instantly with Reduce Motion. The saved reading position is updated.
- The control state lives in a separate `@Observable` object read only by the controls, so showing or fading them never re-evaluates the `ScrollView`, in line with the file's no-per-pixel-publishing approach. Edges are derived in the existing `onScrollGeometryChange` and published only when they change.
- macOS 26 uses interactive glass circles like the composer's attachment button; macOS 15 uses a material circle.

### Bottom detection fix

`TranscriptScrollView` passed `ScrollGeometry.containerSize.height` as the viewport height to `TranscriptScrollMetrics`. `containerSize` excludes the titlebar inset: measured in the app, `containerSize` was 758 pt while the visible rect was 810 pt, with a 52 pt top inset. `isAtBottom` therefore stayed false at the real bottom, which kept the Latest button visible. The fix uses `visibleRect.height`. A regression test covers the measured values.

The same metric sets `followsLatest` when a scroll gesture ends. Before this fix, scrolling back to the bottom by hand should have left follow-latest off, so later bot messages would not keep the transcript pinned. I found this by reading the code and have not separately verified it in the app. The resize fixture did not catch it because its window has no top inset.

## Verification

- `swift test --disable-sandbox`: 431 tests, 1 failure in `ToolCatalogTests.testSearchAndCustomMCPStaySeparate`. That test also fails on `main` without this change.
- New `TranscriptScrollMetricsTests` cover `isAtTop` and the measured bottom values.
- Manually tested in a local debug build on macOS 26: both buttons appear while scrolling, hide at their edges and after scrolling stops, and jump correctly. The bottom fix was diagnosed from geometry logged in the running app.
- `Tests/transcript-resize.swift` now clicks both controls and checks the jumps, the saved viewport, follow-latest after the jump, and the fade. Caveats:
  - `Tests/transcript-resize.sh` fails to link on `main` because `ComputerBridge` objects are missing from its `swiftc` line. I ran it by adding `ComputerBridge.build/*.swift.o` by hand and did not change the script.
  - While developing an earlier iteration, which had a second `onScrollGeometryChange` modifier on the ScrollView, the existing resize-anchor checks failed intermittently where `main` passed. The extended fixture passed several runs with that iteration. I have not rerun it on the final commit.

## Visual changes

- [ ] No visual changes
- [x] Visual changes included below

### Before

No way to jump to the latest message or to the start.

### After

Screenshot to follow.

## Checklist

- [x] I tested the affected user flow
- [ ] I considered both default and custom conversation backgrounds where relevant
- [ ] I checked single-line and multiline layouts where relevant
- [ ] I checked the macOS 15 fallback when using newer macOS APIs
